### PR TITLE
docs: add setup-db script and dev setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ Dashboard para pesquisa e análise de CVEs (Common Vulnerabilities and Exposures
 
 ## Getting Started
 
+**Pré-requisitos**: Node.js >=20.9.0 (preferir 22, ver `.nvmrc`), [gh CLI](https://cli.github.com) autenticado.
+
 ```bash
 # Instalar dependências
 npm install
+
+# Provisionar banco de dados de CVEs (~141 MB)
+bash scripts/setup-db.sh
 
 # Rodar em desenvolvimento
 npm run dev
@@ -37,6 +42,8 @@ npm run build
 # Build para GitHub Pages
 npm run build:gh-pages
 ```
+
+Sem o banco de dados, a UI renderiza mas não exibe dados de CVEs ou repositórios.
 
 Acesse http://localhost:3000 para ver a aplicação.
 

--- a/scripts/setup-db.sh
+++ b/scripts/setup-db.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log()   { printf '[INFO]  %s\n' "$*"; }
+error() { printf '[ERROR] %s\n' "$*" >&2; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Missing required command: $1"
+    exit 1
+  fi
+}
+
+require_cmd gh
+require_cmd tar
+
+if ! gh auth status >/dev/null 2>&1; then
+  error "gh is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+RELEASE_TAG="db-snapshots"
+
+log "Repo: ${REPO_SLUG}"
+
+if ! gh release view "$RELEASE_TAG" --repo "$REPO_SLUG" >/dev/null 2>&1; then
+  error "Release '${RELEASE_TAG}' not found in ${REPO_SLUG}"
+  exit 1
+fi
+
+LATEST_ASSET="$(gh release view "$RELEASE_TAG" \
+  --repo "$REPO_SLUG" \
+  --json assets \
+  --jq '.assets
+    | map(select(.name | test("^snapshot-.*\\.tar\\.gz$")))
+    | sort_by(.createdAt)
+    | reverse
+    | .[0].name // ""')"
+
+if [[ -z "$LATEST_ASSET" ]]; then
+  error "No snapshot found in release '${RELEASE_TAG}'"
+  exit 1
+fi
+
+log "Downloading: ${LATEST_ASSET}"
+
+mkdir -p public/db
+
+TMP_FILE="$(mktemp /tmp/suncve-db.XXXXXX.tar.gz)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+gh release download "$RELEASE_TAG" \
+  --repo "$REPO_SLUG" \
+  --pattern "$LATEST_ASSET" \
+  --output "$TMP_FILE"
+
+log "Extracting to public/db/..."
+tar -xzf "$TMP_FILE" -C .
+
+log "Done. Files in public/db/:"
+ls -lh public/db/


### PR DESCRIPTION
## O que muda
Adiciona script `scripts/setup-db.sh` para provisionar o banco de CVEs localmente (~141 MB, baixado do GitHub Release) e atualiza o README com os pré-requisitos e passo a passo de setup.
## Arquivos
| Arquivo | Ação |
|---|---|
| `scripts/setup-db.sh` | Novo — baixa último snapshot do release `db-snapshots` e extrai em `public/db/` |
| `README.md` | Modificado — seção Getting Started com Node >=20.9.0, gh CLI, e setup-db |
## Como testar
```bash
bash scripts/setup-db.sh   # requer gh CLI autenticado
npm run dev                 # http://localhost:3000/dashboard/search/