### PR TITLE
fix: backfill global de fixes, fonte WordPress no README e ajustes de UI

### DIFF
--- a/.github/workflows/db-snapshots.yml
+++ b/.github/workflows/db-snapshots.yml
@@ -115,6 +115,10 @@ jobs:
         run: |
           python scripts/create-manifest.py repos --batch-size "${REPO_BATCH_SIZE}"
 
+      - name: Recalculate commits_fix for all repositories
+        run: |
+          python scripts/create-manifest.py update-fixes
+
       - name: Build DB Artifacts
         run: |
           bash scripts/build-db-artifacts.sh

--- a/src/features/readme/components/readme-page-content.tsx
+++ b/src/features/readme/components/readme-page-content.tsx
@@ -179,7 +179,7 @@ export default function ReadmePageContent() {
     {
       title: t('sources.wordpressTitle'),
       text: t('sources.wordpressText'),
-      url: 'https://wordpress.org/plugins/',
+      url: 'https://github.com/rix4uni/wordpress-plugins',
       color: 'text-cyan-500',
       bg: 'bg-cyan-500/10'
     }
@@ -203,9 +203,25 @@ export default function ReadmePageContent() {
           />
           <Card className='from-primary/5 to-card bg-gradient-to-t'>
             <CardContent className='space-y-3 pt-0'>
-              <p className='text-base leading-relaxed'>{t('purpose.lead')}</p>
+              <p className='text-base leading-relaxed'>
+                {t.rich('purpose.lead', {
+                  b: (c) => (
+                    <strong className='text-foreground font-semibold'>{c}</strong>
+                  ),
+                  hl: (c) => (
+                    <span className='text-primary font-semibold'>{c}</span>
+                  )
+                })}
+              </p>
               <p className='text-muted-foreground leading-relaxed'>
-                {t('purpose.challenge')}
+                {t.rich('purpose.challenge', {
+                  b: (c) => (
+                    <strong className='text-foreground font-semibold'>{c}</strong>
+                  ),
+                  hl: (c) => (
+                    <span className='text-primary font-semibold'>{c}</span>
+                  )
+                })}
               </p>
             </CardContent>
           </Card>
@@ -228,6 +244,17 @@ export default function ReadmePageContent() {
           </div>
         </section>
 
+        {/* Contributors */}
+        <section className='space-y-4'>
+          <SectionHeading
+            icon={IconUsers}
+            badge={t('contributors.badge')}
+            title={t('contributors.title')}
+            lead={t('contributors.lead')}
+          />
+          <Contributors />
+        </section>
+
         {/* What SunCVE offers */}
         <section className='space-y-4'>
           <SectionHeading
@@ -239,11 +266,13 @@ export default function ReadmePageContent() {
           <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3'>
             {offerItems.map((item) => (
               <Card key={item.title} className='@container/card gap-3'>
-                <CardHeader className='flex-row items-center gap-3'>
-                  <div className={`rounded-full p-2 ${item.bg}`}>
-                    <item.icon className={`size-5 ${item.color}`} />
+                <CardHeader className='gap-2'>
+                  <div className='flex items-center gap-3'>
+                    <div className={`rounded-full p-2 ${item.bg}`}>
+                      <item.icon className={`size-5 ${item.color}`} />
+                    </div>
+                    <CardTitle className='text-base'>{item.title}</CardTitle>
                   </div>
-                  <CardTitle className='text-base'>{item.title}</CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className='text-muted-foreground text-sm leading-relaxed'>
@@ -310,17 +339,6 @@ export default function ReadmePageContent() {
               </Card>
             ))}
           </div>
-        </section>
-
-        {/* Contributors */}
-        <section className='space-y-4'>
-          <SectionHeading
-            icon={IconUsers}
-            badge={t('contributors.badge')}
-            title={t('contributors.title')}
-            lead={t('contributors.lead')}
-          />
-          <Contributors />
         </section>
 
         {/* Footer note */}

--- a/src/features/repositories/components/repo-detail-drawer.tsx
+++ b/src/features/repositories/components/repo-detail-drawer.tsx
@@ -154,6 +154,10 @@ export function RepoDetailDrawer({
     ? `https://${repoFullpath}` // wordpress.org/plugins/<slug>
     : `https://github.com/${repoFullpath}`;
 
+  const displayName = name || repoFullpath.split('/').pop() || '';
+  const truncatedName =
+    displayName.length > 100 ? `${displayName.slice(0, 100)}…` : displayName;
+
   const languages = parseJSON<Record<string, number>>(
     repository.languages as string
   );
@@ -198,8 +202,8 @@ export function RepoDetailDrawer({
                     ) : (
                       <IconBrandGithub className='h-6 w-6 shrink-0' />
                     )}
-                    <span className='min-w-0 truncate'>
-                      {name || repoFullpath.split('/').pop()}
+                    <span className='min-w-0 truncate' title={displayName}>
+                      {truncatedName}
                     </span>
                     {isWordpress && (
                       <Badge

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -164,7 +164,7 @@
       "withCommitFix": "With Commit Fix",
       "vulnerabilities": "Known vulnerabilities",
       "inDatabase": "In the vulnerability database",
-      "githubRepos": "GitHub repositories",
+      "githubRepos": "Repositories",
       "linkedToCVEs": "Linked to known CVEs",
       "exploitAvailable": "Exploits available",
       "publicExploits": "Public exploit code found",
@@ -249,7 +249,7 @@
   },
   "repositories": {
     "title": "Repository Search",
-    "description": "Search and filter GitHub repositories linked to vulnerabilities",
+    "description": "Search and filter repositories linked to vulnerabilities",
     "searchPlaceholder": "Search by repository name, path...",
     "stats": {
       "totalRepos": "Total Repositories",
@@ -329,8 +329,8 @@
     "purpose": {
       "badge": "Why we exist",
       "title": "Why SunCVE exists",
-      "lead": "We want to put on record why SunCVE exists: to analyze commits, diffs, and exploits. That is our strategy to understand how CVEs in large repositories happen.",
-      "challenge": "One of our challenges was being able to filter by type of repository with many stars and with a specific tag, and that is what SunCVE was born from.",
+      "lead": "SunCVE exists to answer what few tools answer: <b>how</b> a vulnerability is actually born and fixed inside the code. Instead of just listing CVEs, we analyze the <hl>commits</hl>, the <hl>diffs</hl> and the <hl>exploits</hl> of each flaw — linking the security advisory to the code that caused it and the code that fixed it.",
+      "challenge": "It all started from a practical challenge: filtering vulnerabilities by <b>popular</b> repositories and by <b>specific tags</b>, something no database offered out of the box. Today SunCVE bridges <b>two ecosystems</b> — GitHub and WordPress — in one place, running entirely in your browser.",
       "commitsTitle": "Commits",
       "commitsText": "We read commits to find where a flaw was introduced and where it was fixed.",
       "diffsTitle": "Diffs",
@@ -383,7 +383,7 @@
       "pocTitle": "PoC-in-GitHub",
       "pocText": "Collection of public proofs of concept and exploits associated with CVEs.",
       "wordpressTitle": "WordPress plugins database",
-      "wordpressText": "WordPress plugin directory, with active installs and downloads.",
+      "wordpressText": "rix4uni/wordpress-plugins dataset from the official WordPress directory, with active installs, downloads and last updated date.",
       "visit": "Visit repository"
     },
     "contributors": {

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -333,8 +333,8 @@
     "purpose": {
       "badge": "Por que existimos",
       "title": "Por que o SunCVE existe",
-      "lead": "Queremos deixar registrado o motivo do SunCVE existir: analisar commits, diffs e exploits. Essa é a nossa estratégia para entender como CVEs em grandes repositórios acontecem.",
-      "challenge": "Um dos nossos desafios foi conseguir filtrar por tipo de repositório com muitas estrelas e com uma determinada tag, e foi disso que o SunCVE nasceu.",
+      "lead": "O SunCVE existe para responder o que poucas ferramentas respondem: <b>como</b> uma vulnerabilidade realmente nasce e é corrigida dentro do código. Em vez de só listar CVEs, analisamos os <hl>commits</hl>, os <hl>diffs</hl> e os <hl>exploits</hl> de cada falha — ligando o aviso de segurança ao código que o causou e ao que o corrigiu.",
+      "challenge": "Tudo nasceu de um desafio prático: filtrar vulnerabilidades por repositórios <b>populares</b> e por <b>tags específicas</b>, algo que nenhuma base entregava pronto. Hoje o SunCVE cruza <b>dois ecossistemas</b> — GitHub e WordPress — num só lugar, rodando inteiro no seu navegador.",
       "commitsTitle": "Commits",
       "commitsText": "Lemos os commits para encontrar onde a falha foi introduzida e onde foi corrigida.",
       "diffsTitle": "Diffs",
@@ -387,7 +387,7 @@
       "pocTitle": "PoC-in-GitHub",
       "pocText": "Coleção de provas de conceito e exploits públicos associados a CVEs.",
       "wordpressTitle": "Base de plugins WordPress",
-      "wordpressText": "Diretório de plugins do WordPress, com instalações ativas e downloads.",
+      "wordpressText": "Dataset rix4uni/wordpress-plugins do diretório oficial do WordPress, com instalações ativas, downloads e data de atualização (last updated).",
       "visit": "Visitar repositório"
     },
     "contributors": {


### PR DESCRIPTION
- pipeline: passo global 'update-fixes' recalcula commits_fix_count para todos os repos (WordPress + GitHub), corrigindo "fixes" zerado na UI
- README: fonte WordPress aponta para rix4uni/wordpress-plugins (base real de last_updated/métricas) e texto i18n atualizado
- README: ícones da seção Recursos centralizados, texto "Por que existe" com destaques via t.rich, e Contribuidores movidos para a 2ª seção
- modal lateral de repositórios: título limitado a 100 caracteres com reticências (title completo no hover) para não esconder as demais infos