### PR TITLE
feat: adiciona fontes npm e Packagist e unifica coluna de downloads

### DIFF
--- a/.github/workflows/db-snapshots.yml
+++ b/.github/workflows/db-snapshots.yml
@@ -115,6 +115,16 @@ jobs:
         run: |
           python scripts/create-manifest.py repos --batch-size "${REPO_BATCH_SIZE}"
 
+      - name: Enrich npm Package Metadata
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/create-manifest.py npm
+
+      - name: Enrich Packagist Package Metadata
+        run: |
+          python scripts/create-manifest.py packagist
+
       - name: Recalculate commits_fix for all repositories
         run: |
           python scripts/create-manifest.py update-fixes

--- a/scripts/create-manifest.py
+++ b/scripts/create-manifest.py
@@ -721,7 +721,9 @@ class databaseSQLite:
             updated_repository TEXT,
             ecosystem TEXT DEFAULT 'github',
             active_installs INTEGER,
-            downloaded INTEGER
+            downloaded INTEGER,
+            package_url TEXT,
+            downloads INTEGER
         )
         """)
         
@@ -736,11 +738,26 @@ class databaseSQLite:
             "ALTER TABLE repositories ADD COLUMN ecosystem TEXT DEFAULT 'github'",
             "ALTER TABLE repositories ADD COLUMN active_installs INTEGER",
             "ALTER TABLE repositories ADD COLUMN downloaded INTEGER",
+            # Métricas de pacote unificadas (npm/Packagist/WordPress)
+            "ALTER TABLE repositories ADD COLUMN package_url TEXT",
+            "ALTER TABLE repositories ADD COLUMN downloads INTEGER",
         ):
             try:
                 self.cursor.execute(column_ddl)
             except sqlite3.OperationalError:
                 pass  # Coluna já existe
+
+        # Backfill único: a coluna 'downloads' unifica as métricas de download de todos
+        # os ecossistemas. Snapshots antigos só têm os downloads do WordPress em
+        # 'downloaded'; trazemos esse valor para a coluna canônica. A coluna física
+        # 'downloaded' é mantida apenas por compatibilidade com snapshots distribuídos.
+        try:
+            self.cursor.execute(
+                "UPDATE repositories SET downloads = downloaded "
+                "WHERE downloads IS NULL AND downloaded IS NOT NULL"
+            )
+        except sqlite3.OperationalError:
+            pass
 
         # 1. Tabela Principal de CVEs
         self.cursor.execute("""
@@ -822,6 +839,7 @@ class databaseSQLite:
         self.cursor.execute("CREATE INDEX IF NOT EXISTS idx_repo_cve ON cve_repositories(cve_id)")
         self.cursor.execute("CREATE INDEX IF NOT EXISTS idx_repo_fullpath ON cve_repositories(repository_fullpath)")
         self.cursor.execute("CREATE INDEX IF NOT EXISTS idx_repo_ecosystem ON repositories(ecosystem)")
+        self.cursor.execute("CREATE INDEX IF NOT EXISTS idx_repo_downloads ON repositories(downloads)")
         
         """
         EXEMPLOS DE QUERY CONSULTA:
@@ -1430,6 +1448,34 @@ class databaseSQLite:
                      "about", "settings", "advisories", "security"):
             return None
         return f"{owner}/{repo}"
+
+    def enrichPackage(
+        self,
+        fullpath: str,
+        ecosystem: str,
+        package_url: str | None,
+        downloads: int | None,
+    ) -> bool:
+        """
+        Enriquece um repositório GitHub já existente com metadados de pacote
+        (npm/Packagist): marca o ecossistema, a URL do pacote no registro e a
+        contagem de downloads. Só atualiza repos já verificados (is_exists=1),
+        nunca cria linhas novas. COALESCE preserva valores já gravados quando a
+        fonte atual não tem o dado. Retorna True se alguma linha foi alterada.
+        """
+        if not fullpath:
+            return False
+        self.cursor.execute(
+            """
+            UPDATE repositories SET
+                ecosystem = ?,
+                package_url = COALESCE(?, package_url),
+                downloads = COALESCE(?, downloads)
+            WHERE fullpath = ? AND is_exists = 1
+            """,
+            (ecosystem, package_url, downloads, fullpath),
+        )
+        return self.cursor.rowcount > 0
 
     def cveExists(self, cve_id: str) -> bool:
         self.cursor.execute("SELECT 1 FROM cves WHERE cve_id = ?", (cve_id,))
@@ -3217,7 +3263,7 @@ class WordPressMetadata:
             db.cursor.execute("""
             UPDATE repositories SET
                 active_installs = ?,
-                downloaded = ?,
+                downloads = ?,
                 name = COALESCE(?, name),
                 updated_repository = COALESCE(?, updated_repository)
             WHERE fullpath = ?
@@ -3393,6 +3439,267 @@ class GitHubAdvisory(GitHubArchiveSource):
         return count
 
 
+class NpmPackages:
+    """
+    Enriquece repositórios GitHub já existentes com o pacote npm correspondente.
+
+    Fluxo (cruza referência <-> pacote):
+    1. Baixa data/packages.json de nice-registry/all-the-package-repos
+       (chave = slug do pacote, valor = URL do repositório; pode ou não terminar em .git).
+    2. Inverte o mapa para fullpath GitHub -> [slugs], apenas para repos que já temos.
+    3. Resolve a última branch 'build-*' de nice-registry/download-counts (slug -> downloads)
+       e clona com --depth=1 para ler as contagens só dos slugs que precisamos.
+    4. Para cada repo casado grava ecosystem='npm', package_url (npmjs) e downloads.
+    """
+    PROJECT_ROOT = Path(__file__).parent.parent.absolute()
+    DATA_DIR = PROJECT_ROOT / "data"
+    SOURCE_NAME = "npm-packages"
+
+    PACKAGES_URLS = (
+        "https://raw.githubusercontent.com/nice-registry/all-the-package-repos/master/data/packages.json",
+        "https://raw.githubusercontent.com/nice-registry/all-the-package-repos/main/data/packages.json",
+    )
+    DOWNLOAD_COUNTS_GIT = "https://github.com/nice-registry/download-counts.git"
+
+    @staticmethod
+    def _iterSlugRepo(packages):
+        """Normaliza o packages.json em pares (slug, repoUrl), aceitando dict ou lista."""
+        if isinstance(packages, dict):
+            for slug, repo in packages.items():
+                if isinstance(repo, str):
+                    yield slug, repo
+                elif isinstance(repo, dict):
+                    url = repo.get("repository") or repo.get("url")
+                    if url:
+                        yield slug, url
+        elif isinstance(packages, list):
+            for item in packages:
+                if not isinstance(item, dict):
+                    continue
+                slug = item.get("name") or item.get("slug")
+                repo = item.get("repository") or item.get("repo") or item.get("url")
+                if slug and isinstance(repo, str):
+                    yield slug, repo
+
+    def _resolveLatestBuildBranch(self) -> str | None:
+        """Última branch 'build-*' via git ls-remote (uma chamada, sem clonar tudo)."""
+        import subprocess
+        try:
+            out = subprocess.run(
+                ["git", "ls-remote", "--heads", self.DOWNLOAD_COUNTS_GIT, "build-*"],
+                capture_output=True, text=True, timeout=120, check=True,
+            ).stdout
+        except (subprocess.SubprocessError, OSError, FileNotFoundError) as e:
+            print(f"[WARN] npm: could not list download-counts branches: {e}")
+            return None
+        branches = [
+            line.split("refs/heads/", 1)[1].strip()
+            for line in out.splitlines()
+            if "refs/heads/build-" in line
+        ]
+        # Nomes 'build-2.YYYYMMDD.N' ordenam lexicograficamente == cronologicamente.
+        return max(branches) if branches else None
+
+    @staticmethod
+    def _loadDownloadCounts(clone_dir: Path) -> dict:
+        """Lê o mapa slug -> downloads do branch clonado (download-counts.json)."""
+        candidates = sorted(
+            clone_dir.glob("*.json"),
+            key=lambda p: p.stat().st_size,
+            reverse=True,
+        )
+        # Prioriza o arquivo canônico; senão, o maior JSON que seja um dict de números.
+        ordered = sorted(candidates, key=lambda p: p.name != "download-counts.json")
+        for path in ordered:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if isinstance(data, dict) and data:
+                return data
+        return {}
+
+    def run(self, db: "databaseSQLite") -> None:
+        import subprocess
+        import tempfile
+
+        db.createTable()
+
+        # 1. Repos GitHub já verificados que podem ser pacotes npm.
+        db.cursor.execute(
+            "SELECT fullpath FROM repositories "
+            "WHERE (ecosystem = 'github' OR ecosystem IS NULL) AND is_exists = 1"
+        )
+        our_fullpaths = {row[0] for row in db.cursor.fetchall() if row[0]}
+        if not our_fullpaths:
+            print("[INFO] npm: no verified GitHub repositories to match; skipping")
+            return
+
+        # 2. Baixa packages.json (slug -> repo) e inverte só para os repos que temos.
+        dest = self.DATA_DIR / "all-the-package-repos.json"
+        packages = None
+        for url in self.PACKAGES_URLS:
+            try:
+                download_to(url, dest)
+                packages = json.loads(dest.read_text(encoding="utf-8"))
+                break
+            except (REQUEST_EXCEPTION, json.JSONDecodeError, OSError) as e:
+                print(f"[WARN] npm: failed to fetch {url}: {e}")
+        if packages is None:
+            print("[WARN] npm: could not load all-the-package-repos; skipping")
+            dest.unlink(missing_ok=True)
+            return
+
+        fullpath_to_slugs: dict[str, list[str]] = {}
+        for slug, repo_url in self._iterSlugRepo(packages):
+            fullpath = db._fullpathFromUrl(repo_url)
+            if fullpath and fullpath in our_fullpaths:
+                fullpath_to_slugs.setdefault(fullpath, []).append(slug)
+        dest.unlink(missing_ok=True)
+
+        if not fullpath_to_slugs:
+            print("[INFO] npm: no GitHub repositories matched an npm package; skipping")
+            return
+        print(f"[INFO] npm: {len(fullpath_to_slugs)} repositories matched an npm package")
+
+        # 3. Contagens de download da última branch build-* (clone shallow temporário).
+        counts: dict = {}
+        branch = self._resolveLatestBuildBranch()
+        if branch:
+            with tempfile.TemporaryDirectory() as tmp:
+                clone_dir = Path(tmp) / "download-counts"
+                try:
+                    subprocess.run(
+                        ["git", "clone", "--depth=1", "--single-branch",
+                         "--branch", branch, self.DOWNLOAD_COUNTS_GIT, str(clone_dir)],
+                        capture_output=True, text=True, timeout=600, check=True,
+                    )
+                    counts = self._loadDownloadCounts(clone_dir)
+                    print(f"[INFO] npm: loaded {len(counts)} download counts from {branch}")
+                except (subprocess.SubprocessError, OSError) as e:
+                    print(f"[WARN] npm: failed to clone download-counts@{branch}: {e}")
+        else:
+            print("[WARN] npm: no build-* branch resolved; enriching without download counts")
+
+        # 4. Enriquecimento: em monorepos (vários pacotes no mesmo repo) usa o de maior
+        #    contagem de downloads como representante.
+        enriched = 0
+        for fullpath, slugs in fullpath_to_slugs.items():
+            best_slug = max(
+                slugs,
+                key=lambda s: counts.get(s) or counts.get(s.lower()) or 0,
+            )
+            downloads = counts.get(best_slug) or counts.get(best_slug.lower())
+            downloads = int(downloads) if isinstance(downloads, (int, float)) else None
+            package_url = f"https://www.npmjs.com/package/{best_slug}"
+            if db.enrichPackage(fullpath, "npm", package_url, downloads):
+                enriched += 1
+            if enriched % 500 == 0:
+                db.conn.commit()
+        db.conn.commit()
+
+        started = datetime.now(timezone.utc).isoformat()
+        db.updateSource(self.SOURCE_NAME, started, started, branch or "", base_release_file=branch or "")
+        print(f"[INFO] npm: enriched {enriched} repositories with npm package metadata")
+
+
+class PackagistPackages:
+    """
+    Enriquece repositórios GitHub já existentes com o pacote Packagist correspondente.
+
+    Fluxo:
+    1. Baixa o export OSV de Packagist (all.zip) e coleta affected[].package.name únicos.
+    2. Para cada pacote consulta a API do Packagist (.package.repository e
+       .package.downloads.total).
+    3. Cruza o repositório do pacote com os repos que já temos das referências; em um
+       match grava ecosystem='packagist', package_url e downloads.
+    """
+    PROJECT_ROOT = Path(__file__).parent.parent.absolute()
+    DATA_DIR = PROJECT_ROOT / "data"
+    SOURCE_NAME = "packagist"
+
+    OSV_URL = "https://storage.googleapis.com/osv-vulnerabilities/Packagist/all.zip"
+    API_URL = "https://packagist.org/packages/{name}.json"
+
+    def _collectPackageNames(self) -> list[str]:
+        zip_path = self.DATA_DIR / "packagist-osv.zip"
+        extract_dir = self.DATA_DIR / "packagist-osv"
+        try:
+            download_to(self.OSV_URL, zip_path)
+            if extract_dir.exists():
+                shutil.rmtree(extract_dir)
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zf.extractall(extract_dir)
+        except (REQUEST_EXCEPTION, OSError, zipfile.BadZipFile) as e:
+            print(f"[WARN] packagist: failed to download/extract OSV export: {e}")
+            zip_path.unlink(missing_ok=True)
+            return []
+        finally:
+            zip_path.unlink(missing_ok=True)
+
+        names: set[str] = set()
+        for json_path in extract_dir.glob("**/*.json"):
+            try:
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            for aff in data.get("affected", []) if isinstance(data, dict) else []:
+                pkg = aff.get("package", {}) if isinstance(aff, dict) else {}
+                name = pkg.get("name")
+                if name and "/" in name:
+                    names.add(name)
+        shutil.rmtree(extract_dir, ignore_errors=True)
+        return sorted(names)
+
+    def run(self, db: "databaseSQLite") -> None:
+        db.createTable()
+
+        names = self._collectPackageNames()
+        if not names:
+            print("[INFO] packagist: no package names from OSV export; skipping")
+            return
+        print(f"[INFO] packagist: {len(names)} unique Packagist packages from OSV")
+
+        db.cursor.execute(
+            "SELECT fullpath FROM repositories "
+            "WHERE (ecosystem = 'github' OR ecosystem IS NULL) AND is_exists = 1"
+        )
+        our_fullpaths = {row[0] for row in db.cursor.fetchall() if row[0]}
+        if not our_fullpaths:
+            print("[INFO] packagist: no verified GitHub repositories to match; skipping")
+            return
+
+        enriched = 0
+        for i, name in enumerate(names, 1):
+            try:
+                resp = http_get(self.API_URL.format(name=name))
+                if resp.status_code != 200:
+                    continue
+                pkg = resp.json().get("package", {})
+            except (REQUEST_EXCEPTION, ValueError) as e:
+                print(f"[WARN] packagist: failed to fetch {name}: {e}")
+                continue
+
+            fullpath = db._fullpathFromUrl(pkg.get("repository") or "")
+            if not fullpath or fullpath not in our_fullpaths:
+                continue
+            total = (pkg.get("downloads") or {}).get("total")
+            total = int(total) if isinstance(total, (int, float)) else None
+            package_url = f"https://packagist.org/packages/{name}"
+            if db.enrichPackage(fullpath, "packagist", package_url, total):
+                enriched += 1
+
+            if i % 200 == 0:
+                db.conn.commit()
+                print(f"[INFO] packagist: processed {i}/{len(names)} packages ({enriched} enriched)")
+            time.sleep(0.05)  # educado com a API pública do Packagist
+        db.conn.commit()
+
+        started = datetime.now(timezone.utc).isoformat()
+        db.updateSource(self.SOURCE_NAME, started, started, str(len(names)))
+        print(f"[INFO] packagist: enriched {enriched} repositories with Packagist metadata")
+
+
 def main() -> None:
     import argparse
     import os
@@ -3402,7 +3709,7 @@ def main() -> None:
     )
     parser.add_argument(
         "command",
-        choices=["cves", "cves-ids", "repos", "advisories", "pocs", "wordpress", "update-fixes", "backfill-scores", "manifest", "all"],
+        choices=["cves", "cves-ids", "repos", "advisories", "pocs", "wordpress", "npm", "packagist", "update-fixes", "backfill-scores", "manifest", "all"],
         nargs="?",
         default="cves",
         help=(
@@ -3410,10 +3717,13 @@ def main() -> None:
             "'cves-ids' (import specific CVE IDs), "
             "'advisories' (enrich CVEs from GitHub Advisory Database), "
             "'pocs' (enrich exploit fields from PoC-in-GitHub), "
+            "'wordpress' (enrich WordPress plugins with install/download metrics), "
+            "'npm' (enrich repos with npm package metadata from nice-registry), "
+            "'packagist' (enrich repos with Packagist package metadata), "
             "'update-fixes' (recalculate commits_fix), "
             "'backfill-scores' (recompute CVSS for CVEs missing a valid score), "
             "'manifest' (generate public/db/manifest.json), "
-            "'all' (cves+repos+advisories+pocs+manifest)"
+            "'all' (cves+repos+advisories+pocs+wordpress+npm+packagist+manifest)"
         ),
     )
     parser.add_argument(
@@ -3580,6 +3890,20 @@ def main() -> None:
         db_path = CVElistV5.DATA_DIR / "source.sqlite"
         db = databaseSQLite(db_path)
         WordPressMetadata().run(db)
+        db.conn.close()
+
+    if args.command in ["npm", "all"]:
+        print("[INFO] Enriching repositories with npm package metadata (nice-registry)...")
+        db_path = CVElistV5.DATA_DIR / "source.sqlite"
+        db = databaseSQLite(db_path)
+        NpmPackages().run(db)
+        db.conn.close()
+
+    if args.command in ["packagist", "all"]:
+        print("[INFO] Enriching repositories with Packagist package metadata (OSV + Packagist API)...")
+        db_path = CVElistV5.DATA_DIR / "source.sqlite"
+        db = databaseSQLite(db_path)
+        PackagistPackages().run(db)
         db.conn.close()
 
     if args.command == "backfill-scores":

--- a/src/features/readme/components/readme-page-content.tsx
+++ b/src/features/readme/components/readme-page-content.tsx
@@ -182,6 +182,20 @@ export default function ReadmePageContent() {
       url: 'https://github.com/rix4uni/wordpress-plugins',
       color: 'text-cyan-500',
       bg: 'bg-cyan-500/10'
+    },
+    {
+      title: t('sources.npmTitle'),
+      text: t('sources.npmText'),
+      url: 'https://github.com/nice-registry/all-the-package-repos',
+      color: 'text-rose-500',
+      bg: 'bg-rose-500/10'
+    },
+    {
+      title: t('sources.packagistTitle'),
+      text: t('sources.packagistText'),
+      url: 'https://packagist.org',
+      color: 'text-indigo-500',
+      bg: 'bg-indigo-500/10'
     }
   ];
 

--- a/src/features/repositories/components/repo-detail-drawer.tsx
+++ b/src/features/repositories/components/repo-detail-drawer.tsx
@@ -6,6 +6,9 @@ import {
   IconExternalLink,
   IconBrandGithub,
   IconBrandWordpress,
+  IconBrandNpm,
+  IconBrandPhp,
+  IconPackage,
   IconStar,
   IconCode,
   IconCalendar,
@@ -148,8 +151,10 @@ export function RepoDetailDrawer({
   const updatedRepository = repository.updated_repository as string | null;
   const ecosystem = (repository.ecosystem as string | null) ?? 'github';
   const isWordpress = ecosystem === 'wordpress';
+  const isPackage = ecosystem === 'npm' || ecosystem === 'packagist';
   const activeInstalls = repository.active_installs as number | null;
-  const downloaded = repository.downloaded as number | null;
+  const downloads = repository.downloads as number | null;
+  const packageUrl = repository.package_url as string | null;
   const externalUrl = isWordpress
     ? `https://${repoFullpath}` // wordpress.org/plugins/<slug>
     : `https://github.com/${repoFullpath}`;
@@ -197,20 +202,26 @@ export function RepoDetailDrawer({
               <div className='flex items-start justify-between gap-4'>
                 <div className='min-w-0 flex-1'>
                   <SheetTitle className='flex min-w-0 items-center gap-2 text-xl'>
-                    {isWordpress ? (
-                      <IconBrandWordpress className='h-6 w-6 shrink-0 text-[#21759b]' />
-                    ) : (
-                      <IconBrandGithub className='h-6 w-6 shrink-0' />
-                    )}
+                    {(() => {
+                      const meta = getEcosystemMeta(ecosystem);
+                      return (
+                        <meta.Icon
+                          className={cn('h-6 w-6 shrink-0', meta.textClass)}
+                        />
+                      );
+                    })()}
                     <span className='min-w-0 truncate' title={displayName}>
                       {truncatedName}
                     </span>
-                    {isWordpress && (
+                    {ecosystem !== 'github' && (
                       <Badge
                         variant='outline'
-                        className='shrink-0 border-[#21759b]/50 text-[#21759b]'
+                        className={cn(
+                          'shrink-0',
+                          getEcosystemMeta(ecosystem).borderClass
+                        )}
                       >
-                        WordPress
+                        {getEcosystemMeta(ecosystem).label}
                       </Badge>
                     )}
                   </SheetTitle>
@@ -300,13 +311,13 @@ export function RepoDetailDrawer({
                   </div>
                 </CardContent>
               </Card>
-              {isWordpress ? (
+              {isWordpress || isPackage ? (
                 <Card>
                   <CardContent className='flex items-center gap-2 p-3'>
                     <IconDownload className='h-4 w-4 shrink-0 text-blue-500' />
                     <div className='min-w-0'>
                       <p className='truncate text-lg font-bold sm:text-2xl'>
-                        {formatCount(downloaded)}
+                        {formatCount(downloads)}
                       </p>
                       <p className='text-muted-foreground text-xs'>
                         {t('downloads')}
@@ -349,6 +360,25 @@ export function RepoDetailDrawer({
                 </AccordionTrigger>
                 <AccordionContent>
                   <div className='space-y-4'>
+                    {/* Package registry URL (npm / Packagist) */}
+                    {packageUrl && (
+                      <div>
+                        <p className='text-muted-foreground mb-2 text-sm'>
+                          {t('package')}
+                        </p>
+                        <a
+                          href={packageUrl}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          className='text-primary inline-flex items-center gap-1 text-sm hover:underline'
+                        >
+                          <IconPackage className='h-4 w-4 shrink-0' />
+                          <span className='truncate'>{packageUrl}</span>
+                          <IconExternalLink className='h-3 w-3 shrink-0' />
+                        </a>
+                      </div>
+                    )}
+
                     {/* Main Language */}
                     {languageMain && (
                       <div>
@@ -596,6 +626,39 @@ export function RepoDetailDrawer({
       />
     </Sheet>
   );
+}
+
+function getEcosystemMeta(ecosystem: string) {
+  switch (ecosystem) {
+    case 'wordpress':
+      return {
+        label: 'WordPress',
+        Icon: IconBrandWordpress,
+        textClass: 'text-[#21759b]',
+        borderClass: 'border-[#21759b]/50 text-[#21759b]'
+      };
+    case 'npm':
+      return {
+        label: 'npm',
+        Icon: IconBrandNpm,
+        textClass: 'text-[#cb3837]',
+        borderClass: 'border-[#cb3837]/50 text-[#cb3837]'
+      };
+    case 'packagist':
+      return {
+        label: 'Packagist',
+        Icon: IconBrandPhp,
+        textClass: 'text-[#6082bc]',
+        borderClass: 'border-[#6082bc]/50 text-[#6082bc]'
+      };
+    default:
+      return {
+        label: 'GitHub',
+        Icon: IconBrandGithub,
+        textClass: '',
+        borderClass: ''
+      };
+  }
 }
 
 // Helper function

--- a/src/features/repositories/components/repo-filters-panel.tsx
+++ b/src/features/repositories/components/repo-filters-panel.tsx
@@ -116,20 +116,20 @@ export function RepoFiltersPanel({
   const handleEcosystemChange = useCallback(
     (value: string) => {
       const ecosystem = value === 'all' ? null : value;
-      // Clear WordPress-only thresholds when leaving the WordPress ecosystem
+      // active_installs is WordPress-only; clear it when leaving WordPress.
+      // downloads is the unified metric and applies to any ecosystem, so it stays.
       onFiltersChange({
         ...filters,
         ecosystem,
         activeInstallsMin:
-          ecosystem === 'wordpress' ? filters.activeInstallsMin : null,
-        downloadedMin: ecosystem === 'wordpress' ? filters.downloadedMin : null
+          ecosystem === 'wordpress' ? filters.activeInstallsMin : null
       });
     },
     [filters, onFiltersChange]
   );
 
   const handleNumberFilter = useCallback(
-    (key: 'activeInstallsMin' | 'downloadedMin', raw: string) => {
+    (key: 'activeInstallsMin' | 'downloadsMin', raw: string) => {
       const value = raw.trim() === '' ? null : Number(raw);
       onFiltersChange({
         ...filters,
@@ -302,7 +302,7 @@ export function RepoFiltersPanel({
             </div>
           </div>
 
-          {/* Ecosystem Filter (GitHub / WordPress) */}
+          {/* Ecosystem Filter (GitHub / WordPress / npm / Packagist) */}
           <div className='space-y-3'>
             <Label>{t('ecosystem')}</Label>
             <Select
@@ -316,40 +316,42 @@ export function RepoFiltersPanel({
                 <SelectItem value='all'>{t('ecosystemAll')}</SelectItem>
                 <SelectItem value='github'>GitHub</SelectItem>
                 <SelectItem value='wordpress'>WordPress</SelectItem>
+                <SelectItem value='npm'>npm</SelectItem>
+                <SelectItem value='packagist'>Packagist</SelectItem>
               </SelectContent>
             </Select>
 
+            {/* Min downloads — unified metric, applies to any ecosystem */}
+            <div className='space-y-1'>
+              <span className='text-muted-foreground text-xs'>
+                {t('minDownloads')}
+              </span>
+              <Input
+                type='number'
+                min={0}
+                placeholder='10000'
+                value={filters.downloadsMin ?? ''}
+                onChange={(e) =>
+                  handleNumberFilter('downloadsMin', e.target.value)
+                }
+              />
+            </div>
+
             {filters.ecosystem === 'wordpress' && (
               <div className='space-y-2'>
-                <div className='grid grid-cols-2 gap-2'>
-                  <div className='space-y-1'>
-                    <span className='text-muted-foreground text-xs'>
-                      {t('minActiveInstalls')}
-                    </span>
-                    <Input
-                      type='number'
-                      min={0}
-                      placeholder='1000'
-                      value={filters.activeInstallsMin ?? ''}
-                      onChange={(e) =>
-                        handleNumberFilter('activeInstallsMin', e.target.value)
-                      }
-                    />
-                  </div>
-                  <div className='space-y-1'>
-                    <span className='text-muted-foreground text-xs'>
-                      {t('minDownloads')}
-                    </span>
-                    <Input
-                      type='number'
-                      min={0}
-                      placeholder='10000'
-                      value={filters.downloadedMin ?? ''}
-                      onChange={(e) =>
-                        handleNumberFilter('downloadedMin', e.target.value)
-                      }
-                    />
-                  </div>
+                <div className='space-y-1'>
+                  <span className='text-muted-foreground text-xs'>
+                    {t('minActiveInstalls')}
+                  </span>
+                  <Input
+                    type='number'
+                    min={0}
+                    placeholder='1000'
+                    value={filters.activeInstallsMin ?? ''}
+                    onChange={(e) =>
+                      handleNumberFilter('activeInstallsMin', e.target.value)
+                    }
+                  />
                 </div>
                 <p className='text-muted-foreground text-xs'>
                   {t('thresholdHint')}
@@ -407,7 +409,7 @@ function countActiveFilters(filters: RepositorySearchFilters): number {
   if (filters.hasCVEs !== null) count++;
   if (filters.hasCommitFix !== null) count++;
   if (filters.ecosystem !== null) count++;
-  if (filters.activeInstallsMin !== null || filters.downloadedMin !== null)
+  if (filters.activeInstallsMin !== null || filters.downloadsMin !== null)
     count++;
   return count;
 }

--- a/src/features/repositories/components/repo-results-table.tsx
+++ b/src/features/repositories/components/repo-results-table.tsx
@@ -7,11 +7,12 @@ import {
   IconSelector,
   IconBrandGithub,
   IconBrandWordpress,
+  IconBrandNpm,
+  IconBrandPhp,
   IconStar,
   IconBug,
   IconGitCommit,
   IconCode,
-  IconUsers,
   IconDownload
 } from '@tabler/icons-react';
 import {
@@ -47,7 +48,6 @@ interface RepoResultsTableProps {
   results: RepositorySearchResultsPage | null;
   sort: RepositorySortConfig;
   isLoading: boolean;
-  ecosystem: string | null;
   onSortChange: (sort: RepositorySortConfig) => void;
   onPageChange: (page: number) => void;
   onRowClick: (repo: RepositorySearchResult) => void;
@@ -57,20 +57,12 @@ export function RepoResultsTable({
   results,
   sort,
   isLoading,
-  ecosystem,
   onSortChange,
   onPageChange,
   onRowClick
 }: RepoResultsTableProps) {
   const t = useTranslations('repositories.table');
   const locale = useLocale();
-
-  // WordPress plugins have no stars; the metric column shows installs/downloads,
-  // so sorting it should order by download count instead of stars.
-  const isWordpress = ecosystem === 'wordpress';
-  const metricSortField: RepositorySortField = isWordpress
-    ? 'downloaded'
-    : 'stars';
 
   const handleSort = (field: RepositorySortField) => {
     if (sort.field === field) {
@@ -135,7 +127,7 @@ export function RepoResultsTable({
               overscrollBehaviorX: 'contain'
             }}
           >
-            <Table className='min-w-[800px]'>
+            <Table className='min-w-[1000px]'>
               <TableHeader>
                 <TableRow>
                   <TableHead className='min-w-[250px]'>
@@ -148,14 +140,25 @@ export function RepoResultsTable({
                       <SortIcon field='fullpath' />
                     </Button>
                   </TableHead>
-                  <TableHead className='w-[140px]'>
+                  <TableHead className='w-[120px]'>{t('ecosystem')}</TableHead>
+                  <TableHead className='w-[110px]'>
                     <Button
                       variant='ghost'
                       className='h-8 p-0 font-semibold hover:bg-transparent'
-                      onClick={() => handleSort(metricSortField)}
+                      onClick={() => handleSort('stars')}
                     >
-                      {isWordpress ? t('downloads') : t('stars')}
-                      <SortIcon field={metricSortField} />
+                      {t('stars')}
+                      <SortIcon field='stars' />
+                    </Button>
+                  </TableHead>
+                  <TableHead className='w-[120px]'>
+                    <Button
+                      variant='ghost'
+                      className='h-8 p-0 font-semibold hover:bg-transparent'
+                      onClick={() => handleSort('downloads')}
+                    >
+                      {t('downloads')}
+                      <SortIcon field='downloads' />
                     </Button>
                   </TableHead>
                   <TableHead className='w-[120px]'>{t('language')}</TableHead>
@@ -207,19 +210,9 @@ export function RepoResultsTable({
                           <IconBrandGithub className='text-muted-foreground h-5 w-5 shrink-0' />
                         )}
                         <div className='min-w-0'>
-                          <div className='flex items-center gap-2'>
-                            <span className='truncate font-medium'>
-                              {repo.name || repo.fullpath.split('/').pop()}
-                            </span>
-                            {repo.ecosystem === 'wordpress' && (
-                              <Badge
-                                variant='outline'
-                                className='shrink-0 border-[#21759b]/50 text-[#21759b]'
-                              >
-                                WordPress
-                              </Badge>
-                            )}
-                          </div>
+                          <span className='block truncate font-medium'>
+                            {repo.name || repo.fullpath.split('/').pop()}
+                          </span>
                           <div className='text-muted-foreground truncate text-xs'>
                             {repo.fullpath}
                           </div>
@@ -227,36 +220,37 @@ export function RepoResultsTable({
                       </div>
                     </TableCell>
                     <TableCell>
-                      {repo.ecosystem === 'wordpress' ? (
-                        <div className='flex flex-col gap-0.5 text-sm'>
-                          <span
-                            className='flex items-center gap-1'
-                            title={t('activeInstalls')}
+                      {(() => {
+                        const meta = getEcosystemMeta(repo.ecosystem);
+                        return (
+                          <Badge
+                            variant='outline'
+                            className={cn('gap-1', meta.borderClass)}
                           >
-                            <IconUsers className='h-4 w-4 shrink-0 text-[#21759b]' />
-                            <span className='font-medium'>
-                              {repo.active_installs != null
-                                ? formatCount(repo.active_installs)
-                                : '—'}
-                            </span>
-                          </span>
-                          <span
-                            className='text-muted-foreground flex items-center gap-1'
-                            title={t('downloads')}
-                          >
-                            <IconDownload className='h-4 w-4 shrink-0' />
-                            <span>
-                              {repo.downloaded != null
-                                ? formatCount(repo.downloaded)
-                                : '—'}
-                            </span>
-                          </span>
-                        </div>
-                      ) : repo.stars != null ? (
+                            <meta.Icon className={cn('h-3 w-3', meta.textClass)} />
+                            {meta.label}
+                          </Badge>
+                        );
+                      })()}
+                    </TableCell>
+                    <TableCell>
+                      {repo.stars != null ? (
                         <div className='flex items-center gap-1'>
                           <IconStar className='h-4 w-4 text-yellow-500' />
                           <span className='font-medium'>
                             {formatStars(repo.stars)}
+                          </span>
+                        </div>
+                      ) : (
+                        <span className='text-muted-foreground'>—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {repo.downloads != null ? (
+                        <div className='flex items-center gap-1'>
+                          <IconDownload className='text-muted-foreground h-4 w-4' />
+                          <span className='font-medium'>
+                            {formatCount(repo.downloads)}
                           </span>
                         </div>
                       ) : (
@@ -386,11 +380,13 @@ function TableSkeleton() {
               overscrollBehaviorX: 'contain'
             }}
           >
-            <Table className='min-w-[800px]'>
+            <Table className='min-w-[1000px]'>
               <TableHeader>
                 <TableRow>
                   <TableHead className='min-w-[250px]'>Repository</TableHead>
-                  <TableHead className='w-[100px]'>Stars</TableHead>
+                  <TableHead className='w-[120px]'>Ecosystem</TableHead>
+                  <TableHead className='w-[110px]'>Stars</TableHead>
+                  <TableHead className='w-[120px]'>Downloads</TableHead>
                   <TableHead className='w-[120px]'>Language</TableHead>
                   <TableHead className='w-[100px]'>CVEs</TableHead>
                   <TableHead className='w-[100px]'>Fixes</TableHead>
@@ -403,6 +399,12 @@ function TableSkeleton() {
                   <TableRow key={i}>
                     <TableCell>
                       <Skeleton className='h-10 w-full rounded' />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton className='h-6 w-20 rounded-full' />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton className='h-5 w-16 rounded' />
                     </TableCell>
                     <TableCell>
                       <Skeleton className='h-5 w-16 rounded' />
@@ -431,6 +433,39 @@ function TableSkeleton() {
       </div>
     </div>
   );
+}
+
+function getEcosystemMeta(ecosystem: string | null) {
+  switch (ecosystem) {
+    case 'wordpress':
+      return {
+        label: 'WordPress',
+        Icon: IconBrandWordpress,
+        textClass: 'text-[#21759b]',
+        borderClass: 'border-[#21759b]/50 text-[#21759b]'
+      };
+    case 'npm':
+      return {
+        label: 'npm',
+        Icon: IconBrandNpm,
+        textClass: 'text-[#cb3837]',
+        borderClass: 'border-[#cb3837]/50 text-[#cb3837]'
+      };
+    case 'packagist':
+      return {
+        label: 'Packagist',
+        Icon: IconBrandPhp,
+        textClass: 'text-[#6082bc]',
+        borderClass: 'border-[#6082bc]/50 text-[#6082bc]'
+      };
+    default:
+      return {
+        label: 'GitHub',
+        Icon: IconBrandGithub,
+        textClass: 'text-muted-foreground',
+        borderClass: 'text-muted-foreground'
+      };
+  }
 }
 
 function formatStars(stars: number): string {

--- a/src/features/repositories/components/repo-search-page-content.tsx
+++ b/src/features/repositories/components/repo-search-page-content.tsx
@@ -74,16 +74,21 @@ function RepositorySearchPageContentInner() {
     topLanguages: { language: string; count: number }[];
   }>({ totalRepos: 0, withCVEs: 0, withCommitFix: 0, topLanguages: [] });
 
-  // Keep the sort field meaningful per ecosystem: WordPress plugins have no stars
-  // (sort by downloads instead), and stars is the sensible default elsewhere.
+  // Keep the sort field meaningful per ecosystem: package ecosystems
+  // (WordPress/npm/Packagist) are ranked by downloads, while stars is the sensible
+  // default for plain GitHub repositories.
   useEffect(() => {
-    if (filters.ecosystem === 'wordpress') {
+    const isPackageEcosystem =
+      filters.ecosystem === 'wordpress' ||
+      filters.ecosystem === 'npm' ||
+      filters.ecosystem === 'packagist';
+    if (isPackageEcosystem) {
       setSort((prev) =>
-        prev.field === 'stars' ? { field: 'downloaded', order: 'desc' } : prev
+        prev.field === 'stars' ? { field: 'downloads', order: 'desc' } : prev
       );
     } else {
       setSort((prev) =>
-        prev.field === 'downloaded' || prev.field === 'active_installs'
+        prev.field === 'downloads' || prev.field === 'active_installs'
           ? { field: 'stars', order: 'desc' }
           : prev
       );
@@ -231,7 +236,6 @@ function RepositorySearchPageContentInner() {
           results={results}
           sort={sort}
           isLoading={isSearching || isPending}
-          ecosystem={filters.ecosystem}
           onSortChange={setSort}
           onPageChange={setPage}
           onRowClick={handleRowClick}

--- a/src/features/search/components/cve-detail-drawer.tsx
+++ b/src/features/search/components/cve-detail-drawer.tsx
@@ -361,38 +361,32 @@ export function CVEDetailDrawer({
                           </CardHeader>
                           <CardContent className='p-4 pt-0'>
                             <div className='text-muted-foreground flex flex-wrap gap-4 text-sm'>
-                              {repo.ecosystem === 'wordpress' ? (
-                                <>
-                                  {repo.active_installs != null && (
-                                    <div className='flex items-center gap-1.5'>
-                                      <IconUsers className='h-4 w-4 text-[#21759b]' />
-                                      <span className='font-semibold tabular-nums'>
-                                        {(
-                                          repo.active_installs as number
-                                        ).toLocaleString()}
-                                      </span>
-                                    </div>
-                                  )}
-                                  {repo.downloaded != null && (
-                                    <div className='flex items-center gap-1.5'>
-                                      <IconDownload className='h-4 w-4' />
-                                      <span className='font-semibold tabular-nums'>
-                                        {(
-                                          repo.downloaded as number
-                                        ).toLocaleString()}
-                                      </span>
-                                    </div>
-                                  )}
-                                </>
-                              ) : (
-                                repo.stars !== null && (
+                              {repo.stars != null && (
+                                <div className='flex items-center gap-1.5'>
+                                  <IconStar className='h-4 w-4 text-yellow-500' />
+                                  <span className='font-semibold tabular-nums'>
+                                    {(repo.stars as number).toLocaleString()}
+                                  </span>
+                                </div>
+                              )}
+                              {repo.ecosystem === 'wordpress' &&
+                                repo.active_installs != null && (
                                   <div className='flex items-center gap-1.5'>
-                                    <IconStar className='h-4 w-4 text-yellow-500' />
+                                    <IconUsers className='h-4 w-4 text-[#21759b]' />
                                     <span className='font-semibold tabular-nums'>
-                                      {(repo.stars as number).toLocaleString()}
+                                      {(
+                                        repo.active_installs as number
+                                      ).toLocaleString()}
                                     </span>
                                   </div>
-                                )
+                                )}
+                              {repo.downloads != null && (
+                                <div className='flex items-center gap-1.5'>
+                                  <IconDownload className='h-4 w-4' />
+                                  <span className='font-semibold tabular-nums'>
+                                    {(repo.downloads as number).toLocaleString()}
+                                  </span>
+                                </div>
                               )}
                               {Boolean(repo.languageMain) && (
                                 <div className='flex items-center gap-1.5'>

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -58,9 +58,10 @@ export interface Repository {
   scm_id_repository: string | null;
   created_repository: string | null;
   updated_repository: string | null;
-  ecosystem: string | null; // 'github' | 'wordpress'
+  ecosystem: string | null; // 'github' | 'wordpress' | 'npm' | 'packagist'
   active_installs: number | null; // WordPress plugins only
-  downloaded: number | null; // WordPress plugins only
+  downloads: number | null; // unified download count (npm/Packagist/WordPress)
+  package_url: string | null; // registry URL (npm/Packagist)
 }
 
 export interface RepositoryRelation {
@@ -125,7 +126,7 @@ export interface SearchFilters {
   customDate: string | null; // For specific date (YYYY-MM-DD)
   repository: string | null; // Filter by specific repository fullpath
   cweCategory: string | null; // Filter by CWE category (e.g., 'rce', 'injection')
-  ecosystem: string | null; // Filter by linked repository ecosystem ('wordpress' | 'github')
+  ecosystem: string | null; // Filter by linked repository ecosystem ('github' | 'wordpress' | 'npm' | 'packagist')
   // Popularity: CVE in a repo matching ANY of the set thresholds (combined with OR)
   popStarsMin: number | null; // GitHub stars
   popInstallsMin: number | null; // WordPress active installs
@@ -223,9 +224,9 @@ export interface RepositorySearchFilters {
   sizeMax: number | null;
   hasCVEs: boolean | null;
   hasCommitFix: boolean | null;
-  ecosystem: string | null; // 'github' | 'wordpress' | null (all)
+  ecosystem: string | null; // 'github' | 'wordpress' | 'npm' | 'packagist' | null (all)
   activeInstallsMin: number | null; // WordPress plugins
-  downloadedMin: number | null; // WordPress plugins
+  downloadsMin: number | null; // unified downloads (any ecosystem)
 }
 
 export const defaultRepositoryFilters: RepositorySearchFilters = {
@@ -239,7 +240,7 @@ export const defaultRepositoryFilters: RepositorySearchFilters = {
   hasCommitFix: null,
   ecosystem: null,
   activeInstallsMin: null,
-  downloadedMin: null
+  downloadsMin: null
 };
 
 export interface RepositorySearchResult {
@@ -254,7 +255,8 @@ export interface RepositorySearchResult {
   updated_repository: string | null;
   ecosystem: string | null;
   active_installs: number | null;
-  downloaded: number | null;
+  downloads: number | null;
+  package_url: string | null;
 }
 
 export interface RepositorySearchResultsPage {
@@ -275,7 +277,7 @@ export type RepositorySortField =
   | 'created_repository'
   | 'updated_repository'
   | 'active_installs'
-  | 'downloaded';
+  | 'downloads';
 
 export interface RepositorySortConfig {
   field: RepositorySortField;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -286,6 +286,7 @@
     },
     "table": {
       "repository": "Repository",
+      "ecosystem": "Ecosystem",
       "stars": "Stars",
       "language": "Language",
       "cves": "CVEs",
@@ -305,6 +306,7 @@
       "activeInstalls": "Active Installs",
       "downloads": "Downloads",
       "size": "Size",
+      "package": "Package",
       "repoInfo": "Repository Info",
       "mainLanguage": "Main Language",
       "languages": "Languages",
@@ -384,6 +386,10 @@
       "pocText": "Collection of public proofs of concept and exploits associated with CVEs.",
       "wordpressTitle": "WordPress plugins database",
       "wordpressText": "rix4uni/wordpress-plugins dataset from the official WordPress directory, with active installs, downloads and last updated date.",
+      "npmTitle": "npm packages",
+      "npmText": "nice-registry/all-the-package-repos maps each npm package to its repository, cross-referenced with download counts from nice-registry/download-counts to enrich GitHub repos with package URL and downloads.",
+      "packagistTitle": "Packagist packages",
+      "packagistText": "OSV Packagist export plus the Packagist API resolve each affected Composer package to its repository and total downloads, matched against the repositories from our references.",
       "visit": "Visit repository"
     },
     "contributors": {

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -290,6 +290,7 @@
     },
     "table": {
       "repository": "Repositório",
+      "ecosystem": "Ecossistema",
       "stars": "Stars",
       "language": "Linguagem",
       "cves": "CVEs",
@@ -309,6 +310,7 @@
       "activeInstalls": "Instalações Ativas",
       "downloads": "Downloads",
       "size": "Tamanho",
+      "package": "Pacote",
       "repoInfo": "Informações do Repositório",
       "mainLanguage": "Linguagem Principal",
       "languages": "Linguagens",
@@ -388,6 +390,10 @@
       "pocText": "Coleção de provas de conceito e exploits públicos associados a CVEs.",
       "wordpressTitle": "Base de plugins WordPress",
       "wordpressText": "Dataset rix4uni/wordpress-plugins do diretório oficial do WordPress, com instalações ativas, downloads e data de atualização (last updated).",
+      "npmTitle": "Pacotes npm",
+      "npmText": "O nice-registry/all-the-package-repos mapeia cada pacote npm ao seu repositório, cruzado com as contagens de download de nice-registry/download-counts para enriquecer repos do GitHub com URL do pacote e downloads.",
+      "packagistTitle": "Pacotes Packagist",
+      "packagistText": "O export OSV de Packagist e a API do Packagist resolvem cada pacote Composer afetado para o seu repositório e total de downloads, cruzados com os repositórios das nossas referências.",
       "visit": "Visitar repositório"
     },
     "contributors": {

--- a/src/lib/sqlite/sqlite-loader.ts
+++ b/src/lib/sqlite/sqlite-loader.ts
@@ -526,6 +526,37 @@ export async function ensureDatabaseStored(
 }
 
 /**
+ * Migrações defensivas aplicadas ao banco recém-aberto.
+ *
+ * O snapshot é carregado read-only do disco, mas o sql.js o mantém em memória de
+ * forma gravável (as alterações não são persistidas). Isso garante que um snapshot
+ * mais antigo, gerado antes destas colunas existirem, não quebre as queries que
+ * fazem SELECT delas — fechando a janela entre publicar o front e regenerar o
+ * snapshot. As DDLs são idempotentes: se a coluna já existe, o erro é ignorado.
+ */
+function applyClientSchemaMigrations(db: SqlJsDatabase): void {
+  const addColumns = [
+    'ALTER TABLE repositories ADD COLUMN downloads INTEGER',
+    'ALTER TABLE repositories ADD COLUMN package_url TEXT'
+  ];
+  for (const sql of addColumns) {
+    try {
+      db.run(sql);
+    } catch {
+      // Coluna já existe (snapshot já migrado) — ignora.
+    }
+  }
+  // Unifica os downloads legados do WordPress ('downloaded') na coluna canônica.
+  try {
+    db.run(
+      'UPDATE repositories SET downloads = downloaded WHERE downloads IS NULL AND downloaded IS NOT NULL'
+    );
+  } catch {
+    // 'downloaded' pode não existir em snapshots muito antigos — ignora.
+  }
+}
+
+/**
  * Abre o banco de dados
  */
 export async function openDatabase(
@@ -537,6 +568,7 @@ export async function openDatabase(
   if (store.location === 'opfs' && store.handle) {
     const bytes = await readOpfsFile(store.handle);
     const db = new SQL.Database(bytes);
+    applyClientSchemaMigrations(db);
     return {
       db,
       SQL,
@@ -548,6 +580,7 @@ export async function openDatabase(
 
   if (store.location === 'memory' && store.buffer) {
     const db = new SQL.Database(store.buffer);
+    applyClientSchemaMigrations(db);
     return {
       db,
       SQL,
@@ -592,6 +625,7 @@ export async function loadDatabaseFromUrl(
   });
 
   const db = new SQL.Database(buffer);
+  applyClientSchemaMigrations(db);
   return {
     db,
     SQL,

--- a/src/lib/sqlite/use-cve-search.ts
+++ b/src/lib/sqlite/use-cve-search.ts
@@ -157,7 +157,7 @@ export function useCVESearch() {
           popParams.push(filters.popInstallsMin);
         }
         if (filters.popDownloadsMin !== null) {
-          popConds.push('r.downloaded >= ?');
+          popConds.push('r.downloads >= ?');
           popParams.push(filters.popDownloadsMin);
         }
         if (popConds.length > 0) {
@@ -555,7 +555,7 @@ export function useCVESearch() {
       const repositories = executeQuery(
         `
         SELECT r.fullpath, r.stars, r.languageMain, r.size,
-               r.ecosystem, r.name, r.active_installs, r.downloaded
+               r.ecosystem, r.name, r.active_installs, r.downloads, r.package_url
         FROM cve_repositories cr
         JOIN repositories r ON cr.repository_fullpath = r.fullpath
         WHERE cr.cve_id = ?

--- a/src/lib/sqlite/use-repository-search.ts
+++ b/src/lib/sqlite/use-repository-search.ts
@@ -109,21 +109,22 @@ export function useRepositorySearch() {
         }
       }
 
-      // WordPress install/download thresholds. When both are set they combine with OR
+      // Install/download thresholds. Active installs is WordPress-only; downloads is the
+      // unified metric (npm/Packagist/WordPress). When both are set they combine with OR
       // (e.g. >1000 active installs OR >10000 downloads); a single one applies on its own.
       const installCond =
         filters.activeInstallsMin !== null ? 'r.active_installs >= ?' : null;
       const downloadCond =
-        filters.downloadedMin !== null ? 'r.downloaded >= ?' : null;
+        filters.downloadsMin !== null ? 'r.downloads >= ?' : null;
       if (installCond && downloadCond) {
         conditions.push(`(${installCond} OR ${downloadCond})`);
-        params.push(filters.activeInstallsMin!, filters.downloadedMin!);
+        params.push(filters.activeInstallsMin!, filters.downloadsMin!);
       } else if (installCond) {
         conditions.push(installCond);
         params.push(filters.activeInstallsMin!);
       } else if (downloadCond) {
         conditions.push(downloadCond);
-        params.push(filters.downloadedMin!);
+        params.push(filters.downloadsMin!);
       }
 
       const where =
@@ -180,8 +181,8 @@ export function useRepositorySearch() {
           case 'active_installs':
             orderBy = `r.active_installs ${sort.order.toUpperCase()} NULLS LAST`;
             break;
-          case 'downloaded':
-            orderBy = `r.downloaded ${sort.order.toUpperCase()} NULLS LAST`;
+          case 'downloads':
+            orderBy = `r.downloads ${sort.order.toUpperCase()} NULLS LAST`;
             break;
         }
 
@@ -216,7 +217,8 @@ export function useRepositorySearch() {
             r.updated_repository,
             r.ecosystem,
             r.active_installs,
-            r.downloaded,
+            r.downloads,
+            r.package_url,
             tc.total
           FROM repositories r
           INNER JOIN filtered_repos fr ON fr.fullpath = r.fullpath
@@ -249,7 +251,8 @@ export function useRepositorySearch() {
           updated_repository: row.updated_repository,
           ecosystem: row.ecosystem,
           active_installs: row.active_installs,
-          downloaded: row.downloaded
+          downloads: row.downloads,
+          package_url: row.package_url
         }));
 
         return {


### PR DESCRIPTION
- npm (nice-registry/all-the-package-repos + download-counts) e Packagist (OSV + API do Packagist) enriquecem os repos com ecossistema, package_url e downloads, cruzando a referência com o repositório do pacote
- coluna downloads unificada (WordPress migra de downloaded), nova coluna de ecossistema na tabela e package_url no drawer de detalhes
- passos npm/packagist na action de snapshot e migração defensiva do schema ao abrir o banco no front