### PR TITLE
feat(nuclei): Wordfence templates + missing template indicator

### DIFF
--- a/scripts/create-manifest.py
+++ b/scripts/create-manifest.py
@@ -791,6 +791,27 @@ class databaseSQLite:
             except sqlite3.OperationalError:
                 pass  # Coluna já existe
 
+        # Migração: campos KEV (CISA Known Exploited Vulnerabilities)
+        for column_ddl in (
+            "ALTER TABLE cves ADD COLUMN in_kev BOOLEAN DEFAULT 0",
+            "ALTER TABLE cves ADD COLUMN kev_date_added TEXT",
+            "ALTER TABLE cves ADD COLUMN kev_due_date TEXT",
+            "ALTER TABLE cves ADD COLUMN kev_ransomware BOOLEAN DEFAULT 0",
+        ):
+            try:
+                self.cursor.execute(column_ddl)
+            except sqlite3.OperationalError:
+                pass  # Coluna já existe
+
+        # Migração: missing template indicator (edoardottt/missing-cve-nuclei-templates)
+        for column_ddl in (
+            "ALTER TABLE cves ADD COLUMN missing_nuclei_template BOOLEAN DEFAULT 0",
+        ):
+            try:
+                self.cursor.execute(column_ddl)
+            except sqlite3.OperationalError:
+                pass  # Coluna já existe
+
         # 2. Tabela de Scores (1 CVE -> N Scores)
         self.cursor.execute("""
         CREATE TABLE IF NOT EXISTS cve_scores (
@@ -3908,6 +3929,81 @@ class WordfenceNucleiTemplates:
         )
 
 
+class MissingNucleiTemplates:
+    """
+    Enriquece CVEs com indicador de "template ausente" baseado na lista semanal do
+    repositorio edoardottt/missing-cve-nuclei-templates.
+
+    Contem 65k+ CVEs que NAO possuem template no repositorio oficial do Nuclei,
+    organizadas por ano em data/year/YYYY.txt.
+    Formato: [ CVE-YYYY-NNNNN ] [ vuln_type ] URL
+    """
+
+    BASE_URL = (
+        "https://raw.githubusercontent.com/edoardottt/"
+        "missing-cve-nuclei-templates/main/data/year"
+    )
+    SOURCE_NAME = "missing-nuclei-templates"
+
+    _CVE_LINE_RE = re.compile(r"\[ (CVE-\d{4}-\d{4,}) \]")
+
+    @staticmethod
+    def _parseCveIds(text: str) -> list[str]:
+        return [
+            m.group(1).upper()
+            for m in MissingNucleiTemplates._CVE_LINE_RE.finditer(text)
+        ]
+
+    def run(self, db: "databaseSQLite") -> None:
+        db.createTable()
+
+        started = datetime.now(timezone.utc).isoformat()
+        total_cves = 0
+        enriched = 0
+
+        for year in range(1999, datetime.now().year + 1):
+            url = f"{self.BASE_URL}/{year}.txt"
+            try:
+                resp = http_get(url, headers={"User-Agent": "SunCVE/1.0"}, timeout=30)
+                if resp.status_code == 404:
+                    continue
+                resp.raise_for_status()
+                text = resp.text
+            except Exception as e:
+                print(f"  [WARN] missing-templates: year {year} download failed: {e}")
+                continue
+
+            cve_ids = set(self._parseCveIds(text))
+            year_enriched = 0
+
+            for cve_id in cve_ids:
+                if db.cveExists(cve_id):
+                    db.cursor.execute(
+                        "UPDATE cves SET missing_nuclei_template = 1 WHERE cve_id = ?",
+                        (cve_id,),
+                    )
+                    year_enriched += 1
+
+            total_cves += len(cve_ids)
+            enriched += year_enriched
+            db.conn.commit()
+            print(
+                f"  [INFO] missing-templates: year {year} — "
+                f"{len(cve_ids)} CVEs listed, {year_enriched} in database"
+            )
+
+        print(
+            f"[INFO] missing-templates: {total_cves} CVEs missing template, "
+            f"{enriched} enriched in database"
+        )
+        db.updateSource(
+            self.SOURCE_NAME,
+            started,
+            started,
+            datetime.now(timezone.utc).isoformat(),
+        )
+
+
 class RepoManifestScanner:
     """
     Descobre o NOME canônico do pacote de cada repositório lendo o manifesto raiz
@@ -4757,6 +4853,13 @@ def main() -> None:
         db_path = CVElistV5.DATA_DIR / "source.sqlite"
         db = databaseSQLite(db_path)
         WordfenceNucleiTemplates().run(db)
+        db.conn.close()
+
+    if args.command in ["missing-templates", "all"]:
+        print("[INFO] Enriching with missing nuclei template indicator...")
+        db_path = CVElistV5.DATA_DIR / "source.sqlite"
+        db = databaseSQLite(db_path)
+        MissingNucleiTemplates().run(db)
         db.conn.close()
 
     if args.command in ["wordpress", "all"]:

--- a/scripts/create-manifest.py
+++ b/scripts/create-manifest.py
@@ -3700,6 +3700,214 @@ class GitHubAdvisory(GitHubArchiveSource):
         return count
 
 
+class KevEnrichment:
+    """
+    Enriquece CVEs com dados do CISA Known Exploited Vulnerabilities (KEV) Catalog.
+
+    Baixa o JSON oficial do CISA KEV e atualiza as colunas:
+    - in_kev: 1 se a CVE está no catálogo
+    - kev_date_added: data em que a CVE foi adicionada ao KEV
+    - kev_due_date: prazo de remediação (BOD 26-04)
+    - kev_ransomware: 1 se a CVE é conhecida por uso em campanhas de ransomware
+    """
+
+    PROJECT_ROOT = Path(__file__).parent.parent.absolute()
+    DATA_DIR = PROJECT_ROOT / "data"
+
+    KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+
+    def run(self, db: "databaseSQLite") -> None:
+        db.createTable()
+
+        print(f"[INFO] kev: downloading CISA KEV catalog from {self.KEV_URL} ...")
+        try:
+            resp = http_get(
+                self.KEV_URL, headers={"User-Agent": "SunCVE/1.0"}, timeout=60
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            print(f"[WARN] kev: failed to download KEV JSON: {e}")
+            return
+
+        vulnerabilities = data.get(
+            "vulnerabilities", data if isinstance(data, list) else []
+        )
+        title = data.get("title", "") if isinstance(data, dict) else ""
+        catalog_version = (
+            data.get("catalogVersion", "") if isinstance(data, dict) else ""
+        )
+
+        print(
+            f'[INFO] kev: catalog "{title}" version {catalog_version} '
+            f"with {len(vulnerabilities)} entries"
+        )
+
+        updated = 0
+        skipped = 0
+
+        for entry in vulnerabilities:
+            if not isinstance(entry, dict):
+                continue
+            cve_id = entry.get("cveID", "").strip().upper()
+            if not cve_id or not cve_id.startswith("CVE-"):
+                continue
+
+            if not db.cveExists(cve_id):
+                skipped += 1
+                continue
+
+            date_added = entry.get("dateAdded", "")
+            due_date = entry.get("dueDate", "")
+            known_ransomware = entry.get("knownRansomwareCampaignUse", "Unknown")
+            ransomware_val = 1 if known_ransomware == "Known" else 0
+
+            db.cursor.execute(
+                """
+                UPDATE cves SET
+                  in_kev = 1,
+                  kev_date_added = ?,
+                  kev_due_date = ?,
+                  kev_ransomware = ?
+                WHERE cve_id = ?
+                """,
+                (date_added, due_date, ransomware_val, cve_id),
+            )
+            updated += 1
+
+        db.conn.commit()
+        print(
+            f"[INFO] kev: enriched {updated} CVEs, {skipped} KEV entries not in database"
+        )
+
+
+class WordfenceNucleiTemplates:
+    """
+    Enriquece CVEs com templates Nuclei do repositório topscoder/nuclei-wordfence-cve.
+
+    Contém 77k+ templates WordPress gerados a partir do feed de inteligência do
+    Wordfence, organizados por ano em nuclei-templates/YYYY/CVE-YYYY-NNNNN-*.yaml.
+    Usa Git Trees API (não-recursiva) iterando por diretório de ano para evitar
+    o limite de 5MB da API recursiva (o repo tem 77k arquivos).
+
+    Cada template é adicionado ao list_nuclei da CVE com source='wordfence'.
+    """
+
+    REPO = "topscoder/nuclei-wordfence-cve"
+    BRANCH = "main"
+    SOURCE_NAME = "wordfence-nuclei"
+
+    _CVE_FILE_RE = re.compile(r"^(CVE-\d{4}-\d{4,})", re.IGNORECASE)
+
+    @staticmethod
+    def _getTree(repo: str, sha: str) -> dict | None:
+        url = f"https://api.github.com/repos/{repo}/git/trees/{sha}"
+        try:
+            resp = http_get(url, headers=_github_api_headers())
+            if resp.status_code != 200:
+                print(f"  [WARN] wordfence-nuclei: trees API HTTP {resp.status_code}")
+                return None
+            return resp.json()
+        except (REQUEST_EXCEPTION, ValueError) as e:
+            print(f"  [WARN] wordfence-nuclei: trees API failed: {e}")
+            return None
+
+    def run(self, db: "databaseSQLite") -> None:
+        db.createTable()
+
+        head_sha = github_branch_head_sha(self.REPO, self.BRANCH)
+        if not head_sha:
+            print(f"[WARN] wordfence-nuclei: could not resolve HEAD sha; skipping")
+            return
+
+        started = datetime.now(timezone.utc).isoformat()
+
+        root_tree = self._getTree(self.REPO, head_sha)
+        if not root_tree:
+            return
+
+        templates_sha = None
+        for node in root_tree.get("tree", []):
+            if node.get("path") == "nuclei-templates" and node.get("type") == "tree":
+                templates_sha = node["sha"]
+                break
+
+        if not templates_sha:
+            print("[WARN] wordfence-nuclei: nuclei-templates dir not found")
+            return
+
+        templates_tree = self._getTree(self.REPO, templates_sha)
+        if not templates_tree:
+            return
+
+        enriched = 0
+        total_templates = 0
+
+        for node in templates_tree.get("tree", []):
+            if node.get("type") != "tree":
+                continue
+
+            year_dir = node["path"]
+            year_sha = node["sha"]
+
+            year_tree = self._getTree(self.REPO, year_sha)
+            if not year_tree:
+                continue
+
+            cve_map: dict[str, list[dict]] = {}
+
+            for file_node in year_tree.get("tree", []):
+                if file_node.get("type") != "blob":
+                    continue
+
+                name = file_node["path"]
+                match = self._CVE_FILE_RE.match(name)
+                if not match:
+                    continue
+
+                cve_id = match.group(1).upper()
+                if not cve_id.startswith("CVE-"):
+                    continue
+
+                template_url = (
+                    f"https://raw.githubusercontent.com/{self.REPO}/{self.BRANCH}"
+                    f"/nuclei-templates/{year_dir}/{name}"
+                )
+
+                if cve_id not in cve_map:
+                    cve_map[cve_id] = []
+
+                cve_map[cve_id].append(
+                    {
+                        "template_id": Path(name).stem,
+                        "path": f"nuclei-templates/{year_dir}/{name}",
+                        "url": template_url,
+                        "source": "wordfence",
+                    }
+                )
+
+            year_enriched = 0
+            for cve_id, templates in cve_map.items():
+                if db.cveExists(cve_id) and db.addNucleiTemplates(cve_id, templates):
+                    year_enriched += 1
+
+            total_templates += sum(len(v) for v in cve_map.values())
+            enriched += year_enriched
+            db.conn.commit()
+            print(
+                f"  [INFO] wordfence-nuclei: year {year_dir} — "
+                f"{len(cve_map)} CVEs, {year_enriched} enriched"
+            )
+
+        print(
+            f"[INFO] wordfence-nuclei: {total_templates} templates, "
+            f"{enriched} CVEs enriched total"
+        )
+        db.updateSource(
+            self.SOURCE_NAME, started, started, head_sha, base_release_file=head_sha
+        )
+
+
 class RepoManifestScanner:
     """
     Descobre o NOME canônico do pacote de cada repositório lendo o manifesto raiz
@@ -4533,6 +4741,22 @@ def main() -> None:
         db_path = CVElistV5.DATA_DIR / "source.sqlite"
         db = databaseSQLite(db_path)
         NucleiTemplates().run(db, force_full=args.full)
+        db.conn.close()
+
+    if args.command in ["kev", "all"]:
+        print("[INFO] Enriching with CISA KEV catalog...")
+        db_path = CVElistV5.DATA_DIR / "source.sqlite"
+        db = databaseSQLite(db_path)
+        KevEnrichment().run(db)
+        db.conn.close()
+
+    if args.command in ["wordfence-nuclei", "all"]:
+        print(
+            "[INFO] Enriching with Wordfence Nuclei templates (topscoder/nuclei-wordfence-cve)..."
+        )
+        db_path = CVElistV5.DATA_DIR / "source.sqlite"
+        db = databaseSQLite(db_path)
+        WordfenceNucleiTemplates().run(db)
         db.conn.close()
 
     if args.command in ["wordpress", "all"]:

--- a/src/features/search/components/filters-panel.tsx
+++ b/src/features/search/components/filters-panel.tsx
@@ -123,7 +123,7 @@ export function FiltersPanel({
 
   const handleBooleanFilter = useCallback(
     (
-      key: 'hasExploit' | 'hasRepository' | 'hasCommitFix' | 'hasNuclei',
+      key: 'hasExploit' | 'hasRepository' | 'hasCommitFix' | 'hasNuclei' | 'hasKev' | 'hasMissingTemplate',
       value: boolean | null
     ) => {
       onFiltersChange({ ...filters, [key]: value });
@@ -436,6 +436,20 @@ export function FiltersPanel({
                   onChange={(v) => handleBooleanFilter('hasNuclei', v)}
                 />
               </div>
+              <div className='flex items-center justify-between'>
+                <span className='text-sm'>{t('hasKev')}</span>
+                <TriStateSwitch
+                  value={filters.hasKev}
+                  onChange={(v) => handleBooleanFilter('hasKev', v)}
+                />
+              </div>
+              <div className='flex items-center justify-between'>
+                <span className='text-sm'>{t('hasMissingTemplate')}</span>
+                <TriStateSwitch
+                  value={filters.hasMissingTemplate}
+                  onChange={(v) => handleBooleanFilter('hasMissingTemplate', v)}
+                />
+              </div>
             </div>
           </div>
 
@@ -676,6 +690,9 @@ function countActiveFilters(filters: SearchFilters): number {
   if (filters.hasExploit !== null) count++;
   if (filters.hasRepository !== null) count++;
   if (filters.hasCommitFix !== null) count++;
+  if (filters.hasNuclei !== null) count++;
+  if (filters.hasKev !== null) count++;
+  if (filters.hasMissingTemplate !== null) count++;
   if (filters.languages.length > 0) count++;
   if (filters.starsMin !== null || filters.starsMax !== null) count++;
   if (filters.repoSizeMin !== null || filters.repoSizeMax !== null) count++;

--- a/src/features/search/components/results-table.tsx
+++ b/src/features/search/components/results-table.tsx
@@ -229,6 +229,22 @@ export function ResultsTable({
                             <IconTargetArrow className='h-3 w-3' />
                           </Badge>
                         )}
+                        {cve.in_kev && (
+                          <Badge
+                            variant='secondary'
+                            className='bg-amber-500/20 px-1.5 text-amber-700 dark:text-amber-400'
+                          >
+                            <IconShieldExclamation className='h-3 w-3' />
+                          </Badge>
+                        )}
+                        {cve.missing_nuclei_template && (
+                          <Badge
+                            variant='outline'
+                            className='border-dashed border-purple-500/50 px-1.5 text-purple-600 dark:text-purple-400'
+                          >
+                            <IconTargetArrow className='h-3 w-3 opacity-50' />
+                          </Badge>
+                        )}
                       </div>
                     </TableCell>
                     <TableCell className='overflow-hidden'>

--- a/src/features/search/hooks/use-search-params.ts
+++ b/src/features/search/hooks/use-search-params.ts
@@ -89,6 +89,8 @@ const searchParamsConfig = {
   repo: parseAsNullableBoolean,
   commit: parseAsNullableBoolean,
   nuclei: parseAsNullableBoolean,
+  kev: parseAsNullableBoolean,
+  missing: parseAsNullableBoolean,
 
   // Language filter (comma-separated)
   lang: parseAsArrayOf(parseAsString).withDefault([]),
@@ -144,6 +146,8 @@ export function useSearchParams() {
       hasRepository: params.repo,
       hasCommitFix: params.commit,
       hasNuclei: params.nuclei,
+      hasKev: params.kev,
+      hasMissingTemplate: params.missing,
       languages: params.lang.filter(Boolean),
       starsMin: params.starsMin,
       starsMax: params.starsMax,
@@ -185,6 +189,8 @@ export function useSearchParams() {
         repo: newFilters.hasRepository,
         commit: newFilters.hasCommitFix,
         nuclei: newFilters.hasNuclei,
+        kev: newFilters.hasKev,
+        missing: newFilters.hasMissingTemplate,
         lang: newFilters.languages.length > 0 ? newFilters.languages : null,
         starsMin: newFilters.starsMin,
         starsMax: newFilters.starsMax,
@@ -237,6 +243,8 @@ export function useSearchParams() {
       repo: null,
       commit: null,
       nuclei: null,
+      kev: null,
+      missing: null,
       lang: null,
       starsMin: null,
       starsMax: null,
@@ -267,6 +275,8 @@ export function useSearchParams() {
       filters.hasRepository !== null ||
       filters.hasCommitFix !== null ||
       filters.hasNuclei !== null ||
+      filters.hasKev !== null ||
+      filters.hasMissingTemplate !== null ||
       filters.languages.length > 0 ||
       filters.starsMin !== null ||
       filters.starsMax !== null ||

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -11,6 +11,11 @@ export interface CVE {
   exists_exploit: boolean;
   exists_commit: boolean;
   exists_nuclei: boolean;
+  in_kev: boolean;
+  kev_date_added: string | null;
+  kev_due_date: string | null;
+  kev_ransomware: boolean;
+  missing_nuclei_template: boolean;
   list_exploit: string | null; // JSON string
   list_commit: string | null; // JSON string
   list_references: string | null; // JSON string
@@ -130,6 +135,8 @@ export interface SearchFilters {
   hasRepository: boolean | null;
   hasCommitFix: boolean | null;
   hasNuclei: boolean | null;
+  hasKev: boolean | null;
+  hasMissingTemplate: boolean | null;
   languages: string[];
   starsMin: number | null;
   starsMax: number | null;
@@ -155,6 +162,8 @@ export const defaultFilters: SearchFilters = {
   hasRepository: null,
   hasCommitFix: null,
   hasNuclei: null,
+  hasKev: null,
+  hasMissingTemplate: null,
   languages: [],
   starsMin: null,
   starsMax: null,
@@ -196,6 +205,10 @@ export interface CVESearchResult {
   exists_exploit: boolean;
   exists_commit: boolean;
   exists_nuclei: boolean;
+  in_kev: boolean;
+  kev_date_added: string | null;
+  kev_ransomware: boolean;
+  missing_nuclei_template: boolean;
   max_score: number | null;
   severity: Severity;
   cwe_list: string | null;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -194,6 +194,8 @@
       "hasRepository": "Has Repository",
       "hasCommitFix": "Has Commit Fix",
       "hasNuclei": "Has Nuclei",
+      "hasKev": "In KEV (CISA)",
+      "hasMissingTemplate": "No Nuclei Template",
       "ecosystem": "Ecosystem",
       "ecosystemAll": "All",
       "popDownloads": "Downloads",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -198,6 +198,8 @@
       "hasRepository": "Com Repositório",
       "hasCommitFix": "Com Commit Fix",
       "hasNuclei": "Com Nuclei",
+      "hasKev": "No KEV (CISA)",
+      "hasMissingTemplate": "Sem Template Nuclei",
       "ecosystem": "Ecossistema",
       "ecosystemAll": "Todos",
       "popDownloads": "Downloads",

--- a/src/lib/sqlite/use-cve-search.ts
+++ b/src/lib/sqlite/use-cve-search.ts
@@ -129,6 +129,17 @@ export function useCVESearch() {
         params.push(filters.hasNuclei ? 1 : 0);
       }
 
+      // KEV (CISA Known Exploited Vulnerabilities) - direct column check (fast)
+      if (filters.hasKev !== null) {
+        conditions.push('c.in_kev = ?');
+        params.push(filters.hasKev ? 1 : 0);
+      }
+
+      if (filters.hasMissingTemplate !== null) {
+        conditions.push('c.missing_nuclei_template = ?');
+        params.push(filters.hasMissingTemplate ? 1 : 0);
+      }
+
       // Ecosystem filter - CVEs linked to a repository of the given ecosystem.
       // 'github' treats legacy NULL rows as github.
       if (filters.ecosystem) {
@@ -409,6 +420,10 @@ export function useCVESearch() {
             c.exists_exploit,
             c.exists_commit,
             c.exists_nuclei,
+            c.in_kev,
+            c.kev_date_added,
+            c.kev_ransomware,
+            c.missing_nuclei_template,
             COALESCE(s.max_score, 0) as max_score,
             cw.cwe_list,
             a.vendor_list,
@@ -450,6 +465,10 @@ export function useCVESearch() {
           exists_exploit: Boolean(row.exists_exploit),
           exists_commit: Boolean(row.exists_commit),
           exists_nuclei: Boolean(row.exists_nuclei),
+          in_kev: Boolean(row.in_kev),
+          kev_date_added: row.kev_date_added as string | null,
+          kev_ransomware: Boolean(row.kev_ransomware),
+          missing_nuclei_template: Boolean(row.missing_nuclei_template),
           max_score: row.max_score,
           cwe_list: row.cwe_list,
           vendor_list: row.vendor_list,

--- a/src/lib/sqlite/use-repository-search.ts
+++ b/src/lib/sqlite/use-repository-search.ts
@@ -352,6 +352,10 @@ export function useRepositorySearch() {
         exists_exploit: number;
         exists_commit: number;
         exists_nuclei: number;
+        in_kev: number;
+        kev_date_added: string | null;
+        kev_ransomware: number;
+        missing_nuclei_template: number;
         max_score: number | null;
         relation_type: string | null;
       }>(
@@ -365,6 +369,10 @@ export function useRepositorySearch() {
           c.exists_exploit,
           c.exists_commit,
           c.exists_nuclei,
+          c.in_kev,
+          c.kev_date_added,
+          c.kev_ransomware,
+          c.missing_nuclei_template,
           (SELECT MAX(score) FROM cve_scores WHERE cve_id = c.cve_id) as max_score,
           cr.relation_type
         FROM cve_repositories cr
@@ -386,6 +394,10 @@ export function useRepositorySearch() {
         exists_exploit: Boolean(cve.exists_exploit),
         exists_commit: Boolean(cve.exists_commit),
         exists_nuclei: Boolean(cve.exists_nuclei),
+        in_kev: Boolean(cve.in_kev),
+        kev_date_added: cve.kev_date_added,
+        kev_ransomware: Boolean(cve.kev_ransomware),
+        missing_nuclei_template: Boolean(cve.missing_nuclei_template),
         max_score: cve.max_score,
         severity: getSeverityFromScore(cve.max_score ?? 0),
         cwe_list: null,


### PR DESCRIPTION
Duas novas fontes de enriquecimento para templates Nuclei:

**1. Wordfence Nuclei Templates** (`topscoder/nuclei-wordfence-cve`)
- 77k+ templates WordPress gerados do feed Wordfence
- Git Trees API não-recursiva (por ano) para evitar limite de 5MB
- Templates com `source='wordfence'` no `list_nuclei`
- Comando `wordfence-nuclei`

**2. Missing template indicator** (`edoardottt/missing-cve-nuclei-templates`)
- 65k+ CVEs sem template no repo oficial do Nuclei
- Coluna `missing_nuclei_template` + badge tracejado (roxo) + filtro
- Comando `missing-templates`